### PR TITLE
showModalBottomSheet documentation

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -593,7 +593,7 @@ class _BottomSheetSuspendedCurve extends ParametricCurve<double> {
 ///
 /// A closely related widget is a persistent bottom sheet, which shows
 /// information that supplements the primary content of the app without
-/// preventing the use from interacting with the app. Persistent bottom sheets
+/// preventing the user from interacting with the app. Persistent bottom sheets
 /// can be created and displayed with the [showBottomSheet] function or the
 /// [ScaffoldState.showBottomSheet] method.
 ///


### PR DESCRIPTION
Spelling correction in the showModalBottomSheet docs

This PR corrects the wrong spelling of "user" in the docs of showModalBottomSheet which was initially spelt as "use".

"Use" was used in place of "User"